### PR TITLE
0.5.1 Initial build

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+
+aggregate_check: false
+
+upload_channels:
+  - forklift
+
+channels:
+  - services
+  - forklift

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,0 @@
-
-aggregate_check: false
-
-upload_channels:
-  - forklift
-
-channels:
-  - services
-  - forklift

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 build:
   number: 0
   skip: true  # [py<37]
+  skip: true  # [win]
   script:
     - export USE_SYSTEM_LIBS=TRUE
     - {{ PYTHON }} -m pip install . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,8 +54,7 @@ test:
     {% set tests_to_skip = tests_to_skip + " or test_fsspec_memory_list" %}
     {% set tests_to_skip = tests_to_skip + " or test_elastic_training_dl1_backend_gloo" %}
     {% set tests_to_skip = tests_to_skip + " or test_elastic_training_dl2_backend_gloo" %}
-    # unclear this fails only on py<=39
-    {% set tests_to_skip = tests_to_skip + " or test_fsspec_io_iterdatapipe" %}  # [py<=39]
+    {% set tests_to_skip = tests_to_skip + " or test_fsspec_io_iterdatapipe" %}
     # test_audio_examples uses an uninstalled local folder ("examples");
     # avoid test_text_examples due to cycle since torchtext depends on torchdata
     - pytest -v --ignore=test_audio_examples.py --ignore=test_text_examples.py -k "not ({{ tests_to_skip }})"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,6 @@ source:
 
 build:
   number: 0
-  # no pytorch on windows in conda-forge, see
-  # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/32
-  skip: true  # [win]
   script:
     - export BUILD_S3=TRUE
     - export CMAKE_GENERATOR="Ninja"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,7 +60,6 @@ about:
   license_file: LICENSE
   dev_url: https://github.com/pytorch/data
   doc_url: https://pytorch.org/data/beta/index.html
-  doc_source_url: https://github.com/pytorch/data/tree/main/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ build:
   number: 0
   skip: true  # [py<37]
   skip: true  # [win or s390x]
-  skip: true  # [ppc64le and py>=3.11]
+  skip: true  # [ppc64le and py>=311]
   script:
     - export USE_SYSTEM_LIBS=TRUE
     - {{ PYTHON }} -m pip install . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,18 +46,6 @@ test:
     - s3fs
   source_files:
     - test/
-  commands:
-    - pip check
-    - cd test
-    {% set tests_to_skip = "_not_a_real_test" %}
-    # flaky tests
-    {% set tests_to_skip = tests_to_skip + " or test_fsspec_memory_list" %}
-    {% set tests_to_skip = tests_to_skip + " or test_elastic_training_dl1_backend_gloo" %}
-    {% set tests_to_skip = tests_to_skip + " or test_elastic_training_dl2_backend_gloo" %}
-    {% set tests_to_skip = tests_to_skip + " or test_fsspec_io_iterdatapipe" %}
-    # test_audio_examples uses an uninstalled local folder ("examples");
-    # avoid test_text_examples due to cycle since torchtext depends on torchdata
-    - pytest -v --ignore=test_audio_examples.py --ignore=test_text_examples.py -k "not ({{ tests_to_skip }})"
 
 about:
   home: https://github.com/pytorch/data

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ test:
     - test/
 
 about:
-  home: https://github.com/pytorch/data
+  home: https://pytorch.org/
   summary: A PyTorch repo for data loading and utilities to be shared by the PyTorch domain libraries.
   description: |
     torchdata is a library of common modular data loading primitives for easily constructing flexible 
@@ -58,6 +58,9 @@ about:
   license_family: BSD
   license: BSD-3-Clause
   license_file: LICENSE
+  dev_url: https://github.com/pytorch/data
+  doc_url: https://pytorch.org/data/beta/index.html
+  doc_source_url: https://github.com/pytorch/data/tree/main/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   skip: true  # [py<37]
-  skip: true  # [win or s390x]
+  skip: true  # [win]
   skip: true  # [ppc64le and py>=311]
   script:
     - export USE_SYSTEM_LIBS=TRUE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   skip: true  # [py<37]
-  skip: true  # [win]
+  skip: true  # [win or s390x]
   skip: true  # [ppc64le and py>=311]
   script:
     - export USE_SYSTEM_LIBS=TRUE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   host:
     - pip
     - python
-    - pytorch
+    - pytorch 1.13.1
     - setuptools
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 build:
   number: 0
   skip: true  # [py<37]
-  skip: true  # [win]
+  skip: true  # [win or s390x]
+  skip: true  # [ppc64le and py>=3.11]
   script:
     - export USE_SYSTEM_LIBS=TRUE
     - {{ PYTHON }} -m pip install . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - pybind11
     - aws-sdk-cpp
     - pytorch
+    - setuptools
+    - wheel
   run:
     - python
     - requests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
   host:
     - pip
     - python
-    - pybind11
     - pytorch
     - setuptools
     - wheel
@@ -56,6 +55,8 @@ about:
     torchdata is a library of common modular data loading primitives for easily constructing flexible 
     and performant data pipelines. It aims to provide composable Iterable-style and Map-style building
     blocks called DataPipes that work well out of the box with the PyTorch's DataLoader.
+  license_family: BSD
+  license: BSD-3-Clause
   license_file: LICENSE
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   skip: true  # [py<37]
-  skip: true  # [win or s390x]
+  skip: true  # [win]
   skip: true  # [ppc64le and py>=311]
   script:
     - export USE_SYSTEM_LIBS=TRUE
@@ -40,7 +40,7 @@ test:
   requires:
     - pip
     - pytest
-    - datasets
+    - datasets  # [not s390x]
     - expecttest
     - fsspec
     - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - requests
     - urllib3 >=1.25
     - portalocker >=2.0.0
-    - pytorch
+    - pytorch 1.13.1
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,6 @@ build:
   number: 0
   skip: true  # [py<37]
   script:
-    - export BUILD_S3=TRUE
-    - export CMAKE_GENERATOR="Ninja"
     - export USE_SYSTEM_LIBS=TRUE
     - {{ PYTHON }} -m pip install . -vv
 
@@ -21,12 +19,10 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - cmake
-    - ninja
   host:
     - pip
     - python
     - pybind11
-    - aws-sdk-cpp
     - pytorch
     - setuptools
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
     - datasets
     - expecttest
     - fsspec
-    - numpy *
+    - numpy
     - s3fs
   source_files:
     - test/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,10 @@ test:
 about:
   home: https://github.com/pytorch/data
   summary: A PyTorch repo for data loading and utilities to be shared by the PyTorch domain libraries.
-  license: BSD-3-Clause
+  description: |
+    torchdata is a library of common modular data loading primitives for easily constructing flexible 
+    and performant data pipelines. It aims to provide composable Iterable-style and Map-style building
+    blocks called DataPipes that work well out of the box with the PyTorch's DataLoader.
   license_file: LICENSE
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [py<37]
   script:
     - export BUILD_S3=TRUE
     - export CMAKE_GENERATOR="Ninja"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,6 @@ test:
   requires:
     - pip
     - pytest
-    - adlfs
     - datasets
     - expecttest
     - fsspec

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 69d80bd33ce8f08e7cfeeb71cefddfc29cede25a85881e33dbae47576b96ed29
 
 build:
-  number: 2
+  number: 0
   # no pytorch on windows in conda-forge, see
   # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/32
   skip: true  # [win]

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,12 @@
+$PYTHON -m pip check
+ulimit -n 4096
+cd test
+# test_audio_examples uses an uninstalled local folder ("examples");
+# avoid test_text_examples due to cycle since torchtext depends on torchdata
+pytest -v --ignore=test_audio_examples.py \
+--ignore=test_text_examples.py \
+-k "not (_not_a_real_test \
+or test_fsspec_memory_list \
+or test_elastic_training_dl1_backend_gloo \
+or test_elastic_training_dl2_backend_gloo \
+or test_fsspec_io_iterdatapipe)"

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -9,4 +9,6 @@ pytest -v --ignore=test_audio_examples.py \
 or test_fsspec_memory_list \
 or test_elastic_training_dl1_backend_gloo \
 or test_elastic_training_dl2_backend_gloo \
-or test_fsspec_io_iterdatapipe)"
+or test_fsspec_io_iterdatapipe \
+or test_online_iterdatapipe \
+or test_gdrive_iterdatapipe)"


### PR DESCRIPTION
# Links
[Jira Issue](https://anaconda.atlassian.net/browse/PKG-1674)
[Upstream](https://github.com/pytorch/data/tree/v0.5.1)
[Upstream release notes](https://github.com/pytorch/data/releases/tag/v0.5.1)

# Notes
- Removed `aws-cpp-sdk`/`ninja` build system due to issues with `cmake` compatibility. [More info](https://github.com/aws/aws-sdk-cpp/issues/1820)
- Skipping on Windows until `Pytorch 1.13.1` can be built. [More info](https://github.com/AnacondaRecipes/pytorch-feedstock/pull/11)
- Since optional dependency `datasets` is missing on s390x, `TestHuggingFaceHubReader` is skipped.
- Added `test_online_iterdatapipe` and `test_gdrive_iterdatapipe` to flaky tests to be skipped.
- Moved test commands to `run_test.sh` and increased ulimit to fix test issues with some platforms.