### PR TITLE
torchdata 0.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<39]
-  script: {{ PYTHON }} -m pip install --no-deps --ignore-installed --no-build-isolation . -vv
+  skip: true  # [py<310]
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
 
 requirements:
   build:
@@ -33,6 +33,8 @@ requirements:
 test:
   imports:
     - torchdata
+  commands:
+    - pip check
   requires:
     - pip
     - pytest


### PR DESCRIPTION
torchdata 0.11.0

**Destination channel:** defaults

### Links
- [PKG-15619](https://anaconda.atlassian.net/browse/PKG-15619)
- [PKG-14885](https://anaconda.atlassian.net/browse/PKG-14885) (torchtune)
- [PKG-11211](https://anaconda.atlassian.net/browse/PKG-11211)

### Explanation of changes:
- Add `pip check` to `test.commands` (was missing; linter failure blocked post-merge release of PR #5)
- Remove `--ignore-installed` from build script (linter flagged it as unnecessary)
- Update `skip: true # [py<39]` to `# [py<310]` (py3.9 is EOL; pytorch has no py3.9 builds on pkgs/main)
- All builds and tests passed in PR #5 CI; this retriggers the build/release pipeline

[PKG-15619]: https://anaconda.atlassian.net/browse/PKG-15619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-14885]: https://anaconda.atlassian.net/browse/PKG-14885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-11211]: https://anaconda.atlassian.net/browse/PKG-11211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ