### PR TITLE
torchdata: route release to pkgs/main

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40


### PR DESCRIPTION
## torchdata: route release to pkgs/main

**Destination channel:** defaults

### Links

- [PKG-11211](https://anaconda.atlassian.net/browse/PKG-11211) (original 0.11.0)
- [PKG-15619](https://anaconda.atlassian.net/browse/PKG-15619) (linter fix)
- Mis-routed release graph: https://package-build.anaconda.com/v1/graph/0fc78cf1-5e4b-4c08-93f9-acf33c05f4b1

### Explanation of changes:

- Delete `abs.yaml`. Its only content was `upload_channels: [sfe1ed40]`, a personal-staging-channel override left over from local testing. That override is why PR #6's release landed on `anaconda.org/sfe1ed40` instead of `pkgs/main` and never propagated to defaults.
- No recipe changes — the next release graph will use PBP defaults and publish to pkgs/main.

[PKG-11211]: https://anaconda.atlassian.net/browse/PKG-11211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-15619]: https://anaconda.atlassian.net/browse/PKG-15619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ