### PR TITLE
torchdata: bump build number to trigger release

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 945c53a8587567624aaad2d66204fbae9acb9535696554c53ffeb83320c308b9
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
 


### PR DESCRIPTION
## torchdata: bump build number to trigger release

**Destination channel:** defaults

### Links

- [PKG-11211](https://anaconda.atlassian.net/browse/PKG-11211)
- [PKG-15619](https://anaconda.atlassian.net/browse/PKG-15619)
- Previous PR: https://github.com/AnacondaRecipes/torchdata-feedstock/pull/7

### Explanation of changes:

- Bump build number 0 → 1.
- PR #7 deleted abs.yaml to route the release back to pkgs/main, but PBP's graph-submitter reported \"meta.yaml files were not modified, skipping graph generation\" and no build graph fired. Touching meta.yaml forces graph generation. The build-number bump also avoids any collision with the _0 artifacts that were mis-routed to anaconda.org/sfe1ed40.

[PKG-11211]: https://anaconda.atlassian.net/browse/PKG-11211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-15619]: https://anaconda.atlassian.net/browse/PKG-15619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ